### PR TITLE
customisable bar height and circle border width 💅 

### DIFF
--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -24,6 +24,8 @@ export class Switch extends Component {
 		activeTextStyle: Text.propTypes.style,
 		inactiveTextStyle: Text.propTypes.style,
 		containerStyle: View.propTypes.style,
+		barHeight: PropTypes.number,
+		circleBorderWidth: PropTypes.number
 	};
 
 	static defaultProps = {
@@ -37,6 +39,8 @@ export class Switch extends Component {
 		circleActiveColor: 'white',
 		circleInActiveColor: 'white',
 		circleSize: 30,
+		barHeight: 30,
+		circleBorderWidth: 1
 	};
 
 	constructor(props, context) {
@@ -133,7 +137,7 @@ export class Switch extends Component {
 					style={[
 						styles.container,
             containerStyle,
-						{ backgroundColor: interpolatedColorAnimation, width: circleSize * 2, height: circleSize, borderRadius: circleSize }
+						{ backgroundColor: interpolatedColorAnimation, width: circleSize * 2, height: barHeight, borderRadius: circleSize }
 					]}
 				>
 					<Animated.View
@@ -145,7 +149,7 @@ export class Switch extends Component {
 						<Text style={[styles.text, styles.paddingRight, activeTextStyle]}>
 							{activeText}
 						</Text>
-						<Animated.View style={[styles.circle, { backgroundColor: interpolatedCircleColor, width: circleSize, height: circleSize, borderRadius: circleSize / 2 }]} />
+						<Animated.View style={[styles.circle, { borderWidth: circleBorderWidth, backgroundColor: interpolatedCircleColor, width: circleSize, height: circleSize, borderRadius: circleSize / 2 }]} />
 						<Text style={[styles.text, styles.paddingLeft, inactiveTextStyle]}>
 							{inActiveText}
 						</Text>
@@ -177,7 +181,6 @@ const styles = StyleSheet.create({
 		height: 30,
 		borderRadius: 15,
 		backgroundColor: 'white',
-		borderWidth: 1,
 		borderColor: 'rgb(100, 100, 100)',
 	},
 	text: {

--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -39,7 +39,7 @@ export class Switch extends Component {
 		circleActiveColor: 'white',
 		circleInActiveColor: 'white',
 		circleSize: 30,
-		barHeight: 30,
+		barHeight: null,
 		circleBorderWidth: 1
 	};
 
@@ -137,7 +137,7 @@ export class Switch extends Component {
 					style={[
 						styles.container,
             containerStyle,
-						{ backgroundColor: interpolatedColorAnimation, width: circleSize * 2, height: barHeight, borderRadius: circleSize }
+						{ backgroundColor: interpolatedColorAnimation, width: circleSize * 2, height: barHeight ? barHeight : circleSize, borderRadius: circleSize }
 					]}
 				>
 					<Animated.View


### PR DESCRIPTION
Additions: 🙌 
- Customise the background height 
- Remove / Increase width of circle border 

Use case: (thin backbar, no border around circle - looks clean 💅 )
<img width="55" alt="screen shot 2017-11-09 at 14 53 56" src="https://user-images.githubusercontent.com/21029500/32611545-e7bf9a70-c55d-11e7-96f7-2b9c558ed6a7.png">
<img width="47" alt="screen shot 2017-11-09 at 14 53 52" src="https://user-images.githubusercontent.com/21029500/32611546-e7d96478-c55d-11e7-95af-31f9e3820dcc.png">
