### PR TITLE
Much more customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ export const App = () => (
     outerCircleStyle={{}} // style for outer animated circle
     renderActiveText={false}
     renderInActiveText={false}
-    switchLeftPx={1.3} // denominator for logic when sliding to TRUE position. Higher number = more space from RIGHT of the circle to END of the slider
-    switchRightPx={1.3} // denominator for logic when sliding to FALSE position. Higher number = more space from LEFT of the circle to BEGINNING of the slider
-    switchWidthMultiplier={2.75} // multipled by the `circleSize` prop to calculate total width of the Switch
+    switchLeftPx={2} // denominator for logic when sliding to TRUE position. Higher number = more space from RIGHT of the circle to END of the slider
+    switchRightPx={2} // denominator for logic when sliding to FALSE position. Higher number = more space from LEFT of the circle to BEGINNING of the slider
+    switchWidthMultiplier={2} // multipled by the `circleSize` prop to calculate total width of the Switch
   />
 )
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ export const App = () => (
     renderInActiveText={false}
     switchLeftPx={1.1} // denominator for logic when sliding to TRUE position. Higher number = more space from RIGHT of the circle to END of the slider
     switchRightPx={1.} // denominator for logic when sliding to FALSE position. Higher number = more space from LEFT of the circle to BEGINNING of the slider
+    switchWidthMultiplier={2.75} // multipled by the `circleSize` prop to calculate total width of the Switch
   />
 )
 ```

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ export const App = () => (
     circleActiveColor={'#30a566'}
     circleInActiveColor={'#000000'}
     changeValueImmediately={true}
-    renderInsideCircle={() => <CustomComponent />}
-    changeValueImmediately: true // if rendering inside circle, change state immediately or wait for animation to complete
-    innerCircleStyle={{ alignItems: "center", justifyContent: "center" }} // style for inner animated circle
+    renderInsideCircle={() => <CustomComponent />} // custom component to render inside the Switch circle (Text, Image, etc.)
+    changeValueImmediately={true} // if rendering inside circle, change state immediately or wait for animation to complete
+    innerCircleStyle={{ alignItems: "center", justifyContent: "center" }} // style for inner animated circle for what you (may) be rendering inside the circle
     outerCircleStyle={{}} // style for outer animated circle
     renderActiveText={false}
     renderInActiveText={false}
-    switchLeftPx={1.1} // denominator for logic when sliding to TRUE position. Higher number = more space from RIGHT of the circle to END of the slider
-    switchRightPx={1.} // denominator for logic when sliding to FALSE position. Higher number = more space from LEFT of the circle to BEGINNING of the slider
+    switchLeftPx={1.3} // denominator for logic when sliding to TRUE position. Higher number = more space from RIGHT of the circle to END of the slider
+    switchRightPx={1.3} // denominator for logic when sliding to FALSE position. Higher number = more space from LEFT of the circle to BEGINNING of the slider
     switchWidthMultiplier={2.75} // multipled by the `circleSize` prop to calculate total width of the Switch
   />
 )

--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ export const App = () => (
     circleActiveColor={'#30a566'}
     circleInActiveColor={'#000000'}
     changeValueImmediately={true}
-    renderInsideButton={() => <CustomComponent />}
-    buttonStyle={{}}
+    renderInsideCircle={() => <CustomComponent />}
+    changeValueImmediately: true // if rendering inside circle, change state immediately or wait for animation to complete
+    innerCircleStyle={{ alignItems: "center", justifyContent: "center" }} // style for inner animated circle
+    outerCircleStyle={{}} // style for outer animated circle
+    renderActiveText={false}
+    renderInActiveText={false}
   />
 )
 ```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ export const App = () => (
     outerCircleStyle={{}} // style for outer animated circle
     renderActiveText={false}
     renderInActiveText={false}
+    switchLeftPx={1.1} // denominator for logic when sliding to TRUE position. Higher number = more space from RIGHT of the circle to END of the slider
+    switchRightPx={1.} // denominator for logic when sliding to FALSE position. Higher number = more space from LEFT of the circle to BEGINNING of the slider
   />
 )
 ```

--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -10,6 +10,8 @@ import {
 } from "react-native";
 import PropTypes from "prop-types";
 
+const SWITCH_LEFT_PX = 1.05;
+
 export class Switch extends Component {
   static propTypes = {
     onValueChange: PropTypes.func,
@@ -28,16 +30,20 @@ export class Switch extends Component {
     containerStyle: ViewPropTypes.style,
     barHeight: PropTypes.number,
     circleBorderWidth: PropTypes.number,
-    circleStyle: ViewPropTypes.style,
+    innerCircleStyle: ViewPropTypes.style,
     renderInsideCircle: PropTypes.func,
-    changeValueImmediately: PropTypes.bool
+    changeValueImmediately: PropTypes.bool,
+    innerCircleStyle: ViewPropTypes.style,
+    outerCircleStyle: ViewPropTypes.style,
+    renderActiveText: PropTypes.bool,
+    renderInActiveText: PropTypes.bool
   };
 
   static defaultProps = {
     value: false,
     onValueChange: () => null,
     renderInsideCircle: () => null,
-    circleStyle: {},
+    innerCircleStyle: {},
     disabled: false,
     activeText: "On",
     inActiveText: "Off",
@@ -49,7 +55,11 @@ export class Switch extends Component {
     circleSize: 30,
     barHeight: null,
     circleBorderWidth: 1,
-    changeValueImmediately: true
+    changeValueImmediately: true,
+    innerCircleStyle: { alignItems: "center", justifyContent: "center" },
+    outerCircleStyle: {},
+    renderActiveText: false,
+    renderInActiveText: false
   };
 
   constructor(props, context) {
@@ -58,7 +68,9 @@ export class Switch extends Component {
     this.state = {
       value: props.value,
       transformSwitch: new Animated.Value(
-        props.value ? props.circleSize / 2 : -props.circleSize / 2
+        props.value
+          ? props.circleSize / SWITCH_LEFT_PX
+          : -props.circleSize / 1.55
       ),
       backgroundColor: new Animated.Value(props.value ? 75 : -75),
       circleColor: new Animated.Value(props.value ? 75 : -75)
@@ -107,7 +119,9 @@ export class Switch extends Component {
   animateSwitch(value, cb = () => {}) {
     Animated.parallel([
       Animated.spring(this.state.transformSwitch, {
-        toValue: value ? this.props.circleSize / 2 : -this.props.circleSize / 2
+        toValue: value
+          ? this.props.circleSize / SWITCH_LEFT_PX
+          : -this.props.circleSize / 1.55
       }),
       Animated.timing(this.state.backgroundColor, {
         toValue: value ? 75 : -75,
@@ -137,7 +151,10 @@ export class Switch extends Component {
       barHeight,
       circleBorderColor,
       circleBorderWidth,
-      circleStyle
+      innerCircleStyle,
+      outerCircleStyle,
+      renderActiveText,
+      renderInActiveText
     } = this.props;
 
     const interpolatedColorAnimation = backgroundColor.interpolate({
@@ -158,8 +175,8 @@ export class Switch extends Component {
             containerStyle,
             {
               backgroundColor: interpolatedColorAnimation,
-              width: circleSize * 2,
-              height: barHeight ? barHeight : circleSize,
+              width: circleSize * 2.75,
+              height: barHeight || circleSize,
               borderRadius: circleSize
             }
           ]}
@@ -167,12 +184,16 @@ export class Switch extends Component {
           <Animated.View
             style={[
               styles.animatedContainer,
-              { left: transformSwitch, width: circleSize * 2 }
+              { left: transformSwitch, width: circleSize * 2.5 },
+              outerCircleStyle
             ]}
           >
-            <Text style={[styles.text, styles.paddingRight, activeTextStyle]}>
-              {activeText}
-            </Text>
+            {renderActiveText && (
+              <Text style={[styles.text, styles.paddingRight, activeTextStyle]}>
+                activeText
+              </Text>
+            )}
+
             <Animated.View
               style={[
                 styles.circle,
@@ -184,21 +205,24 @@ export class Switch extends Component {
                   height: circleSize,
                   borderRadius: circleSize / 2
                 },
-                circleStyle
+                innerCircleStyle
               ]}
             >
               {this.props.renderInsideCircle()}
             </Animated.View>
-            <Text style={[styles.text, styles.paddingLeft, inactiveTextStyle]}>
-              {inActiveText}
-            </Text>
+            {renderInActiveText && (
+              <Text
+                style={[styles.text, styles.paddingLeft, inactiveTextStyle]}
+              >
+                {inActiveText}
+              </Text>
+            )}
           </Animated.View>
         </Animated.View>
       </TouchableWithoutFeedback>
     );
   }
 }
-// 51 / 31
 
 const styles = StyleSheet.create({
   container: {
@@ -206,7 +230,6 @@ const styles = StyleSheet.create({
     height: 30,
     borderRadius: 30,
     backgroundColor: "black"
-    // overflow: 'hidden'
   },
   animatedContainer: {
     flex: 1,

--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -61,9 +61,9 @@ export class Switch extends Component {
     outerCircleStyle: {},
     renderActiveText: false,
     renderInActiveText: false,
-    switchLeftPx: 1.3,
-    switchRightPx: 1.3,
-    switchWidthMultiplier: 2.75
+    switchLeftPx: 2,
+    switchRightPx: 2,
+    switchWidthMultiplier: 2
   };
 
   constructor(props, context) {

--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -36,7 +36,8 @@ export class Switch extends Component {
     renderActiveText: PropTypes.bool,
     renderInActiveText: PropTypes.bool,
     switchLeftPx: PropTypes.number,
-    switchRightPx: PropTypes.number
+    switchRightPx: PropTypes.number,
+    switchWidthMultiplier: PropTypes.number
   };
 
   static defaultProps = {
@@ -60,8 +61,9 @@ export class Switch extends Component {
     outerCircleStyle: {},
     renderActiveText: false,
     renderInActiveText: false,
-    switchLeftPx: 1.1,
-    switchRightPx: 1.5
+    switchLeftPx: 1.3,
+    switchRightPx: 1.3,
+    switchWidthMultiplier: 2.75
   };
 
   constructor(props, context) {
@@ -156,7 +158,9 @@ export class Switch extends Component {
       innerCircleStyle,
       outerCircleStyle,
       renderActiveText,
-      renderInActiveText
+      renderInActiveText,
+      renderInsideCircle,
+      switchWidthMultiplier
     } = this.props;
 
     const interpolatedColorAnimation = backgroundColor.interpolate({
@@ -177,7 +181,7 @@ export class Switch extends Component {
             containerStyle,
             {
               backgroundColor: interpolatedColorAnimation,
-              width: circleSize * 2.75,
+              width: circleSize * switchWidthMultiplier,
               height: barHeight || circleSize,
               borderRadius: circleSize
             }
@@ -186,7 +190,10 @@ export class Switch extends Component {
           <Animated.View
             style={[
               styles.animatedContainer,
-              { left: transformSwitch, width: circleSize * 2.5 },
+              {
+                left: transformSwitch,
+                width: circleSize * switchWidthMultiplier
+              },
               outerCircleStyle
             ]}
           >
@@ -210,7 +217,7 @@ export class Switch extends Component {
                 innerCircleStyle
               ]}
             >
-              {this.props.renderInsideCircle()}
+              {renderInsideCircle()}
             </Animated.View>
             {renderInActiveText && (
               <Text

--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -10,8 +10,6 @@ import {
 } from "react-native";
 import PropTypes from "prop-types";
 
-const SWITCH_LEFT_PX = 1.05;
-
 export class Switch extends Component {
   static propTypes = {
     onValueChange: PropTypes.func,
@@ -36,7 +34,9 @@ export class Switch extends Component {
     innerCircleStyle: ViewPropTypes.style,
     outerCircleStyle: ViewPropTypes.style,
     renderActiveText: PropTypes.bool,
-    renderInActiveText: PropTypes.bool
+    renderInActiveText: PropTypes.bool,
+    switchLeftPx: PropTypes.number,
+    switchRightPx: PropTypes.number
   };
 
   static defaultProps = {
@@ -59,7 +59,9 @@ export class Switch extends Component {
     innerCircleStyle: { alignItems: "center", justifyContent: "center" },
     outerCircleStyle: {},
     renderActiveText: false,
-    renderInActiveText: false
+    renderInActiveText: false,
+    switchLeftPx: 1.1,
+    switchRightPx: 1.5
   };
 
   constructor(props, context) {
@@ -69,8 +71,8 @@ export class Switch extends Component {
       value: props.value,
       transformSwitch: new Animated.Value(
         props.value
-          ? props.circleSize / SWITCH_LEFT_PX
-          : -props.circleSize / 1.55
+          ? props.circleSize / props.switchLeftPx
+          : -props.circleSize / props.switchRightPx
       ),
       backgroundColor: new Animated.Value(props.value ? 75 : -75),
       circleColor: new Animated.Value(props.value ? 75 : -75)
@@ -120,8 +122,8 @@ export class Switch extends Component {
     Animated.parallel([
       Animated.spring(this.state.transformSwitch, {
         toValue: value
-          ? this.props.circleSize / SWITCH_LEFT_PX
-          : -this.props.circleSize / 1.55
+          ? this.props.circleSize / this.props.switchLeftPx
+          : -this.props.circleSize / this.props.switchRightPx
       }),
       Animated.timing(this.state.backgroundColor, {
         toValue: value ? 75 : -75,


### PR DESCRIPTION
Added the following props:

- innerCircleStyle={{ alignItems: "center", justifyContent: "center" }} // style for inner animated circle for what you (may) be rendering inside the circle
- outerCircleStyle={{}} // style for outer animated circle
- renderActiveText={false}
- renderInActiveText={false}
- switchLeftPx={1.3} // denominator for logic when sliding to TRUE position. Higher number = more space from RIGHT of the circle to END of the slider
- switchRightPx={1.3} // denominator for logic when sliding to FALSE position. Higher number = more space from LEFT of the circle to BEGINNING of the slider
- switchWidthMultiplier={2.75} // multipled by the `circleSize` prop to calculate total width of the Switch