### PR TITLE
Fix activeText not rendring the text from the prop

### DIFF
--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -212,7 +212,7 @@ export class Switch extends Component {
           >
             {renderActiveText && (
               <Text style={[styles.text, styles.paddingRight, activeTextStyle]}>
-                activeText
+                {activeText}
               </Text>
             )}
 


### PR DESCRIPTION
The active text being set in the props was not being displayed i checked the code and added the brackets required for the text to render.