### PR TITLE
Fix for an edge case

### DIFF
--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -92,7 +92,7 @@ export class Switch extends Component {
     if (nextProps.value === this.props.value) {
       return;
     }
-    if (disabled) {
+    if (disabled && nextProps.disabled) {
       return;
     }
 


### PR DESCRIPTION
I've spotted a bug that happens if you update value & disabled together. In that case value doesn't update as this.props.disabled is still true. I've fixed that in this PR.