### PR TITLE
Added the ability to deny switch update when changeValueImmediately is true

### DIFF
--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -89,7 +89,7 @@ export class Switch extends Component {
 
   componentWillReceiveProps(nextProps) {
     const { disabled } = this.props;
-    if (nextProps.value === this.props.value) {
+    if (nextProps.value === this.props.value && nextProps.value === this.state.value) {
       return;
     }
     if (disabled && nextProps.disabled) {
@@ -115,6 +115,7 @@ export class Switch extends Component {
 
     if (changeValueImmediately) {
       this.animateSwitch(!propValue);
+      this.setState({ value: !value });
       onValueChange(!propValue);
     } else {
       this.animateSwitch(!value, () => {


### PR DESCRIPTION
I've found another bug - if changeValueImmediately is set to true it won't update the local state. Also updated componentWillReceiveProps to compare new value to this.state.value. If those differs we need to update switch. This is especially useful if switch update depends on some function which can refuse the new switch value (at least that was my use-case).