### PR TITLE
Add type definition for TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,35 @@
+import { Component, ReactNode } from 'react';
+import { StyleProp, TextStyle, ViewStyle } from 'react-native';
+
+declare type SwitchProps = {
+  onValueChange?: (value: boolean) => void;
+  disabled?: boolean;
+  activeText?: string;
+  inActiveText?: string;
+  backgroundActive?: string;
+  backgroundInactive?: string;
+  value?: boolean;
+  circleActiveColor?: string;
+  circleInActiveColor?: string;
+  circleSize?: number;
+  circleBorderActiveColor?: string;
+  circleBorderInactiveColor?: string;
+  activeTextStyle?: StyleProp<TextStyle>;
+  inactiveTextStyle?: StyleProp<TextStyle>;
+  containerStyle?: StyleProp<ViewStyle>;
+  barHeight?: number;
+  circleBorderWidth?: number;
+  renderInsideCircle?: () => ReactNode;
+  changeValueImmediately?: boolean;
+  innerCircleStyle?: StyleProp<ViewStyle>;
+  outerCircleStyle?: StyleProp<ViewStyle>;
+  renderActiveText?: boolean;
+  renderInActiveText?: boolean;
+  switchLeftPx?: number;
+  switchRightPx?: number;
+  switchWidthMultiplier?: number;
+};
+
+declare class Switch extends Component<SwitchProps> {}
+
+export { Switch, SwitchProps };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.5.0",
   "description": "Customisable switch component for RN",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
I've created a type definitions file based on Switch propTypes and it's source.

### Reason
A type definition file improve module consumers experience providing intellisense on IDEs (Ex. VSCode & Atom) and type safety for TypeScript.

### Changes
- Created type definitions file, `index.d.ts`;
- Exposed type definitions on `package.json`'s `"types"` property;