### PR TITLE
Fix the componentDidUpdate to animation work

### DIFF
--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -85,11 +85,11 @@ export class Switch extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { value } = this.props;
-    if (prevProps.value === this.props.value) {
+    const { value, disabled } = this.props;
+    if (prevProps.value === value) {
       return;
     }
-    if (prevProps.disabled) {
+    if (prevProps.disabled && disabled === prevProps.disabled) {
       return;
     }
 


### PR DESCRIPTION
When update the value and disabled together, the animation don't work
to fix, verify if the prevProps and next are different

I related the problem at [issue](https://github.com/shahen94/react-native-switch/issues/56)