### PR TITLE
Add Border Radius Prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # react-native-switch
-Customisable switch component for RN
+Customisable switch component for RN and React Native Web
 
 ### Installation
 
@@ -41,6 +41,7 @@ export const App = () => (
     switchLeftPx={2} // denominator for logic when sliding to TRUE position. Higher number = more space from RIGHT of the circle to END of the slider
     switchRightPx={2} // denominator for logic when sliding to FALSE position. Higher number = more space from LEFT of the circle to BEGINNING of the slider
     switchWidthMultiplier={2} // multipled by the `circleSize` prop to calculate total width of the Switch
+    switchBorderRadius={30} // Sets the border Radius of the switch slider. If unset, it remains the circleSize.
   />
 )
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,7 @@ declare type SwitchProps = {
   switchLeftPx?: number;
   switchRightPx?: number;
   switchWidthMultiplier?: number;
+  switchBorderRadius?: number;
 };
 
 declare class Switch extends Component<SwitchProps> {}

--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -38,7 +38,8 @@ export class Switch extends Component {
     renderInActiveText: PropTypes.bool,
     switchLeftPx: PropTypes.number,
     switchRightPx: PropTypes.number,
-    switchWidthMultiplier: PropTypes.number
+    switchWidthMultiplier: PropTypes.number,
+    switchBorderRadius: PropTypes.number
   };
 
   static defaultProps = {
@@ -65,7 +66,8 @@ export class Switch extends Component {
     renderInActiveText: true,
     switchLeftPx: 2,
     switchRightPx: 2,
-    switchWidthMultiplier: 2
+    switchWidthMultiplier: 2,
+    switchBorderRadius: null
   };
 
   constructor(props, context) {
@@ -169,6 +171,7 @@ export class Switch extends Component {
       renderInActiveText,
       renderInsideCircle,
       switchWidthMultiplier,
+      switchBorderRadius,
       value
     } = this.props;
 
@@ -197,7 +200,7 @@ export class Switch extends Component {
               backgroundColor: interpolatedColorAnimation,
               width: circleSize * switchWidthMultiplier,
               height: barHeight || circleSize,
-              borderRadius: circleSize
+              borderRadius: switchBorderRadius || circleSize
             }
           ]}
         >

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "ios",
     "mobile",
     "switch",
-    "customisable"
+    "customisable",
+    "react-native-web"
   ],
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Hello,

I'm using this component in a RN/React Native Web Project and wanted to just add a prop that gives me a bit more control of the border radius of the outside switch. Code additions are pretty self explanatory. We add another prop called switchBorderRadius and if it exists, it uses it for the border radius as opposed to the circle size.

Also added a note to the readme that this is compatible with React Native Web!