### PR TITLE
fix switch moving on press despite value not changed

### DIFF
--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -109,6 +109,10 @@ export class Switch extends Component {
     if (disabled) {
       return;
     }
+    if (this.props.value === this.state.value) {
+      onValueChange(!this.state.value);
+      return;
+    }
 
     if (changeValueImmediately) {
       this.animateSwitch(!propValue);


### PR DESCRIPTION
This is an excellent fix. The code comes from @vdanylov's answer  to issue #39 (Value prop not respected properly) [](https://github.com/shahen94/react-native-switch/issues/39) that has been confirmed to work