### PR TITLE
Gather up all additional props and pass them to the touchable

### DIFF
--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -39,8 +39,7 @@ export class Switch extends Component {
     switchLeftPx: PropTypes.number,
     switchRightPx: PropTypes.number,
     switchWidthMultiplier: PropTypes.number,
-    switchBorderRadius: PropTypes.number,
-    testID: PropTypes.string    
+    switchBorderRadius: PropTypes.number
   };
 
   static defaultProps = {
@@ -179,7 +178,7 @@ export class Switch extends Component {
       switchWidthMultiplier,
       switchBorderRadius,
       value,
-      testID
+      ...restProps
     } = this.props;
 
     const interpolatedColorAnimation = backgroundColor.interpolate({
@@ -198,7 +197,7 @@ export class Switch extends Component {
     });
 
     return (
-      <TouchableWithoutFeedback onPress={this.handleSwitch} testID={testID}>
+      <TouchableWithoutFeedback onPress={this.handleSwitch} {...restProps}>
         <Animated.View
           style={[
             styles.container,


### PR DESCRIPTION
This allows us to pass testID, accessibilityLabel, hitSlop, etc to the Switch without having to specify each one individually