### PR TITLE
disabled in componentDidUpdate will stop re-render

### DIFF
--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -89,11 +89,8 @@ export class Switch extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { value, disabled } = this.props;
+    const { value } = this.props;
     if (prevProps.value === value) {
-      return;
-    }
-    if (prevProps.disabled && disabled === prevProps.disabled) {
       return;
     }
 


### PR DESCRIPTION
I'm using `Switch` in some detail screen, so I don't want user to enable it so I disabled it. But I found out that `Switch` will remain false. I remove `disabled` property then it works fine. So I think that's the reason.