### PR TITLE
Fix for warning about useNativeDriver

### DIFF
--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -139,12 +139,12 @@ export class Switch extends Component {
       }),
       Animated.timing(this.state.circleColor, {
         toValue: value ? 75 : -75,
-        duration: 200
+        duration: 200,
         useNativeDriver: false
       }),
       Animated.timing(this.state.circleBorderColor, {
         toValue: value ? 75 : -75,
-        duration: 200
+        duration: 200,
         useNativeDriver: false
       })
     ]).start(cb);

--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -134,15 +134,18 @@ export class Switch extends Component {
       }),
       Animated.timing(this.state.backgroundColor, {
         toValue: value ? 75 : -75,
-        duration: 200
+        duration: 200,
+        useNativeDriver: false
       }),
       Animated.timing(this.state.circleColor, {
         toValue: value ? 75 : -75,
         duration: 200
+        useNativeDriver: false
       }),
       Animated.timing(this.state.circleBorderColor, {
         toValue: value ? 75 : -75,
         duration: 200
+        useNativeDriver: false
       })
     ]).start(cb);
   };

--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -130,7 +130,8 @@ export class Switch extends Component {
       Animated.spring(this.state.transformSwitch, {
         toValue: value
           ? this.props.circleSize / this.props.switchLeftPx
-          : -this.props.circleSize / this.props.switchRightPx
+          : -this.props.circleSize / this.props.switchRightPx,
+        useNativeDriver: false
       }),
       Animated.timing(this.state.backgroundColor, {
         toValue: value ? 75 : -75,


### PR DESCRIPTION
With RN0.62.2, I was getting a warning about needing to specify a value for useNativeDriver. This change eliminates that warning.