### PR TITLE
fix typescript module definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,7 +30,7 @@ declare module 'react-native-switch' {
     switchRightPx?: number;
     switchWidthMultiplier?: number;
     switchBorderRadius?: number;
-  };
+  }
 
-  export class Switch extends Component<SwitchProps> {};
+  export class Switch extends Component<SwitchProps> {}
 }


### PR DESCRIPTION
Fixes typescript check error shown in #84

```
node_modules/react-native-switch/index.d.ts(33,4): error TS1036: Statements are not allowed in ambient contexts.
```