### PR TITLE
fix: remove unused variables

### DIFF
--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -1,12 +1,9 @@
 import React, { Component } from "react";
 import {
-  View,
   Text,
   StyleSheet,
   Animated,
-  PanResponder,
-  TouchableWithoutFeedback,
-  ViewPropTypes
+  TouchableWithoutFeedback
 } from "react-native";
 import PropTypes from "prop-types";
 


### PR DESCRIPTION
ViewPropTypes was depreacted and now longer exists in react-native-web. See: necolas/react-native-web#1537
- Without removing this react-native-web@^0.12.0 will fail to build.

* also removed other variables that were unused
