### PR TITLE
Fix circleBorder color

### DIFF
--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -171,8 +171,8 @@ export class Switch extends Component {
       activeTextStyle,
       inactiveTextStyle,
       barHeight,
-      circleInactiveBorderColor,
-      circleActiveBorderColor,
+      circleBorderInactiveColor,
+      circleBorderActiveColor,
       circleBorderWidth,
       innerCircleStyle,
       outerCircleStyle,
@@ -197,7 +197,7 @@ export class Switch extends Component {
 
     const interpolatedCircleBorderColor = circleBorderColor.interpolate({
       inputRange: [-75, 75],
-      outputRange: [circleInactiveBorderColor, circleActiveBorderColor]
+      outputRange: [circleBorderInactiveColor, circleBorderActiveColor]
     });
 
     return (


### PR DESCRIPTION
The props are incorrectly deconstructed:

```
static propTypes = {
    // ..
    circleBorderActiveColor: PropTypes.string,
    circleBorderInactiveColor: PropTypes.string,
    // ...
  };

// In render
const {
  circleInactiveBorderColor,
  circleActiveBorderColor,
  ...restProps
} = this.props;
```