### PR TITLE
feat: add testID in typescript interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,7 @@ declare module 'react-native-switch' {
     switchRightPx?: number;
     switchWidthMultiplier?: number;
     switchBorderRadius?: number;
+    testID?: string;
   }
 
   export class Switch extends Component<SwitchProps> {}


### PR DESCRIPTION
Fix typescript error on missing `testID` prop

```
No overload matches this call.
  Overload 1 of 2, '(props: SwitchProps | Readonly<SwitchProps>): Switch', gave the following error.
    Type '{ value: false; onValueChange: () => void; testID: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Switch> & Readonly<SwitchProps> & Readonly<{ children?: ReactNode; }>'.
      Property 'testID' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Switch> & Readonly<SwitchProps> & Readonly<{ children?: ReactNode; }>'.
  Overload 2 of 2, '(props: SwitchProps, context: any): Switch', gave the following error.
    Type '{ value: false; onValueChange: () => void; testID: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Switch> & Readonly<SwitchProps> & Readonly<{ children?: ReactNode; }>'.
Property 'testID' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Switch> & Readonly<SwitchProps> & Readonly<{ children?: ReactNode; }>'.ts(2769)
```


![image](https://user-images.githubusercontent.com/40458927/124366756-b2ced980-dc5a-11eb-8ecf-3279e6f4cc39.png)
