### PR TITLE
Update TouchableWithoutFeedback to Pressable so RN Web accessibility features can be passed in

### DIFF
--- a/lib/Switch.js
+++ b/lib/Switch.js
@@ -1,12 +1,9 @@
 import React, { Component } from "react";
 import {
-  View,
   Text,
   StyleSheet,
   Animated,
-  PanResponder,
-  TouchableWithoutFeedback,
-  ViewPropTypes
+  Pressable,
 } from "react-native";
 import PropTypes from "prop-types";
 
@@ -32,7 +29,6 @@ export class Switch extends Component {
     innerCircleStyle: PropTypes.object,
     renderInsideCircle: PropTypes.func,
     changeValueImmediately: PropTypes.bool,
-    innerCircleStyle: PropTypes.object,
     outerCircleStyle: PropTypes.object,
     renderActiveText: PropTypes.bool,
     renderInActiveText: PropTypes.bool,
@@ -46,7 +42,6 @@ export class Switch extends Component {
     value: false,
     onValueChange: () => null,
     renderInsideCircle: () => null,
-    innerCircleStyle: {},
     disabled: false,
     activeText: "On",
     inActiveText: "Off",
@@ -201,7 +196,7 @@ export class Switch extends Component {
     });
 
     return (
-      <TouchableWithoutFeedback onPress={this.handleSwitch} {...restProps}>
+      <Pressable onPress={this.handleSwitch} {...restProps}>
         <Animated.View
           style={[
             styles.container,
@@ -255,7 +250,7 @@ export class Switch extends Component {
             )}
           </Animated.View>
         </Animated.View>
-      </TouchableWithoutFeedback>
+      </Pressable>
     );
   }
 }


### PR DESCRIPTION
Updated the `TouchableWithoutFeedback` component to `Pressable` per guidance by React Native [here](https://reactnative.dev/docs/touchablewithoutfeedback#accessibilitystate) which allows users to pass in accessibility params that are specific to RN Web, and will also still work for RN Mobile (ios/andriod)

Also removed some unused imports